### PR TITLE
Fix:  enable main UI flag and fix topic reference in ICE template

### DIFF
--- a/cli/robocompdsl/robocompdsl/templates/templateCPP/plugins/base/functions/generated/main_cpp.py
+++ b/cli/robocompdsl/robocompdsl/templates/templateCPP/plugins/base/functions/generated/main_cpp.py
@@ -110,7 +110,7 @@ void subscribe( const Ice::CommunicatorPtr& communicator,
                 const std::string& topicBaseName,
                 SpecificWorker* worker,
                 int index,
-                std::shared_ptr<IceStorm::TopicPrx> topic,
+                std::shared_ptr<IceStorm::TopicPrx>& topic,
                 Ice::ObjectPrxPtr& proxy, 
                 const std::string& programName)
 {

--- a/cli/robocompdsl/robocompdsl/templates/templateCPP/plugins/gui/functions/generated/genericworker_h.py
+++ b/cli/robocompdsl/robocompdsl/templates/templateCPP/plugins/gui/functions/generated/genericworker_h.py
@@ -7,6 +7,7 @@ GUI_INCLUDE_STR = """
 	#include <QtGui>
 #endif
 #include <ui_mainUI.h>
+#define USE_QTGUI\n
 """
 
 


### PR DESCRIPTION
## Bug Fix Summary

**Fixed issues with QT GUI and topic subscription:**

1. **Main UI responsiveness**: The main UI was not responding due to a missing enabled flag in the configuration
2. **Topic subscription memory leak**: Added missing reference operator (`&`) in template function parameter for ICE topic handling, preventing improper unsubscription